### PR TITLE
Replace echo -ne with printf.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 	install -c -m 775 *.py $(DESTDIR)knightos-sdk/
 	install -c -m 775 templates/assembly/* $(DESTDIR)knightos-sdk/templates/assembly/
 	install -c -m 775 templates/c/* $(DESTDIR)knightos-sdk/templates/c/
-	echo -ne "#!/bin/sh\n/usr/bin/env python3 $(PREFIX)knightos-sdk/main.py \$$*" > $(DESTDIR)bin/knightos
+	printf "#!/bin/sh\n/usr/bin/env python3 $(PREFIX)knightos-sdk/main.py \$$*" > $(DESTDIR)bin/knightos
 	chmod +x $(DESTDIR)bin/knightos
 
 uninstall:


### PR DESCRIPTION
OS X's `echo` does not support the `-n` flag.
