### PR TITLE
Decode output into ascii

### DIFF
--- a/kpack.py
+++ b/kpack.py
@@ -1,7 +1,4 @@
 import subprocess
-import locale
-
-encoding = locale.getdefaultlocale()[1]
 
 class PackageInfo():
     name = None
@@ -18,7 +15,7 @@ class PackageInfo():
     @staticmethod
     def read_package(path):
         process = subprocess.Popen(['kpack', '-i', path], stdout=subprocess.PIPE)
-        output = process.communicate()[0].decode(encoding)
+        output = process.communicate()[0].decode("ascii")
         result = PackageInfo()
         for line in output.splitlines():
             if not line.strip():


### PR DESCRIPTION
According to https://docs.python.org/2/library/locale.html#locale.getdefaultlocale ```getdefaultlocale``` can return a locale or ```None```, the latter not being handled resulting in an error.