### PR TITLE
set  'verify' flag to false to ignore invalid certificate on PKO

### DIFF
--- a/init.py
+++ b/init.py
@@ -124,14 +124,14 @@ def setup_root(root, project_name, force):
     return exists
 
 def install_kernel(root, platform):
-    releases = requests.get('https://api.github.com/repos/KnightOS/kernel/releases')
+    releases = requests.get('https://api.github.com/repos/KnightOS/kernel/releases', verify=False)
     release = releases.json()[0]
     print("Installing kernel " + release['tag_name'])
     assets = list()
     assets.append([r for r in release['assets'] if r['name'] == 'kernel-' + platform + '.rom'][0])
     for asset in assets:
         stdout.write("Downloading {0}...".format(asset['name']))
-        r = requests.get(asset['browser_download_url'])
+        r = requests.get(asset['browser_download_url'], verify=False)
         total = int(r.headers.get('content-length'))
         length = 0
         with open(os.path.join(root, asset['name']), 'wb') as fd:

--- a/project.py
+++ b/project.py
@@ -73,7 +73,7 @@ class Project:
     def get_implicit_packages(self, packages):
         extra = list()
         for package in packages:
-            info = requests.get('https://packages.knightos.org/api/v1/' + package)
+            info = requests.get('https://packages.knightos.org/api/v1/' + package, verify=False)
             if info.status_code == 404:
                 stderr.write("Cannot find '{0}' on packages.knightos.org.\n".format(package))
                 exit(1)
@@ -118,11 +118,11 @@ class Project:
         # Download packages
         for p in all_packages:
             stdout.write("Downloading {0}".format(p))
-            r = requests.get('https://packages.knightos.org/api/v1/' + p)
+            r = requests.get('https://packages.knightos.org/api/v1/' + p, verify=False)
             path = os.path.join(self.root, ".knightos", "packages", "{0}-{1}.pkg".format(r.json()['name'], r.json()['version']))
             files.append(path)
             with self.open(path, mode="wb") as fd:
-                _r = requests.get('https://packages.knightos.org/{0}/download'.format(r.json()['full_name']))
+                _r = requests.get('https://packages.knightos.org/{0}/download'.format(r.json()['full_name']), verify=False)
                 total = int(_r.headers.get('content-length'))
                 length = 0
                 for chunk in _r.iter_content(1024):


### PR DESCRIPTION
Currently sdk doesn't work due to expired certificate on PKO