### PR TITLE
Updated Makefile to follow GNU Make standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 !templates/**/include
 test
 *.pyc
+knightos.sh

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,26 @@
-PREFIX:=/usr/
-DESTDIR:=/usr/
+prefix:=/usr/local
+bindir:=$(prefix)/bin
+libdir:=$(prefix)/lib
 .PHONY: install
 
-install:
-	mkdir -p $(DESTDIR)bin/
-	mkdir -p $(DESTDIR)knightos-sdk/templates/assembly/
-	mkdir -p $(DESTDIR)knightos-sdk/templates/c/
-	install -c -m 775 *.py $(DESTDIR)knightos-sdk/
-	install -c -m 775 templates/assembly/* $(DESTDIR)knightos-sdk/templates/assembly/
-	install -c -m 775 templates/c/* $(DESTDIR)knightos-sdk/templates/c/
-	install -c -m 775 templates/packages.make $(DESTDIR)knightos-sdk/templates/packages.make
-	printf "#!/bin/sh\n/usr/bin/env python3 $(PREFIX)knightos-sdk/main.py \$$*" > $(DESTDIR)bin/knightos
-	chmod +x $(DESTDIR)bin/knightos
+all: knightos.sh
+
+knightos.sh:
+	printf '#!/bin/sh\n/usr/bin/env python3 "$(prefix)/lib/knightos-sdk/main.py" "$$@"\n' > knightos.sh
+
+install: all
+	mkdir -p "$(bindir)/"
+	mkdir -p "$(libdir)/knightos-sdk/templates/assembly/"
+	mkdir -p "$(libdir)/knightos-sdk/templates/c/"
+	install -c -m 775 *.py "$(libdir)/knightos-sdk/"
+	install -c -m 775 templates/assembly/* "$(libdir)/knightos-sdk/templates/assembly/"
+	install -c -m 775 templates/c/* "$(libdir)/knightos-sdk/templates/c/"
+	install -c -m 775 templates/packages.make "$(libdir)/knightos-sdk/templates/packages.make"
+	install -c -m 775 knightos.sh "$(bindir)/knightos"
 
 uninstall:
-	rm $(DESTDIR)bin/knightos
-	rm -rf $(DESTDIR)knightos-sdk
+	rm "$(bindir)/knightos"
+	rm -rf "$(libdir)/knightos-sdk"
+
+clean:
+	rm knightos.sh


### PR DESCRIPTION
- Code is installed to $prefix/lib/knightos-sdk
  instead of $prefix/knightos-sdk
- The runner-shellscript is generated in an extra step, making it
  possible to get rid of DESTDIR (make prefix=/usr && make install
  prefix=$pkgdir/usr)
- Changed PREFIX to prefix (as recommended for Make)

The Arch PKGBUILD has to be updated as follows:

```shell
build() {
	cd "${srcdir}/sdk-${pkgver}"

	make prefix="/usr"
}

package() {
	cd "${srcdir}/sdk-${pkgver}"

	make install prefix="$pkgdir/usr"
}
```