### PR TITLE
added MANIFEST.in removed package_data from setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include knightos/templates *

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,4 @@ setup(
   license = 'AGPL-3.0',
   scripts=['bin/knightos'],
   include_package_data=True,
-  package_data={
-      'knightos': [
-          'knightos/templates/*',
-          'knightos/templates/c/**/*',
-          'knightos/templates/assembly/**/*',
-      ]
-  },
 )


### PR DESCRIPTION
Here's my attempt at fixing the installer not pulling in the templates. I've tested this with setuptools and distutil and it seems to work under both.