### PR TITLE
Don't fall back to distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-try:
-  from setuptools import setup
-except ImportError:
-  from distutils.core import setup
+from setuptools import setup
+
 from sys import platform
 import subprocess
 import glob


### PR DESCRIPTION
Require setuptools - falling back to distutils causes some important files to not be installed _and doesn't warn the user in any way_.