### PR TITLE
Improve custom kernel

### DIFF
--- a/knightos/templates/assembly/sdk.make
+++ b/knightos/templates/assembly/sdk.make
@@ -22,7 +22,6 @@ kernel:
 	cd {{ kernel_path }} && make $(PLATFORM)
 	cp {{ kernel_path }}/bin/include/kernel.inc $(SDK)include/
 	cp {{ kernel_path }}/bin/include/kernel.h $(SDK)include/
-	cp {{ kernel_path }}/bin/$(PLATFORM)/kernel.rom $(SDK)kernel.rom
 {{/kernel_path}}
 
 run: all


### PR DESCRIPTION
Fixes a `cp` error caused by the symlinking in `knightos init` when using `--kernel-sources`