### PR TITLE
Notify user if invalid package name is passed

### DIFF
--- a/knightos/commands/install.py
+++ b/knightos/commands/install.py
@@ -6,7 +6,10 @@ from knightos.workspace import Workspace
 def execute(packages, site_only=False, init=False, local_path=None):
     ws = Workspace()
     for package in packages:
-        if site_only:
+        if len(package.split("/")) != 2:
+            print("Invalid package name {0}. Format should be `repository/package`.".format(package))
+            break;
+        elif site_only:
             ws.install_package(package, local_path=local_path)
         else:
             ws.require_package(package, local_path=local_path)


### PR DESCRIPTION
Fixes ugly error like so

``` sh
~/D/test> knightos install libc
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/site-packages/knightos-2.0.3_13_ga0841f4-py3.7.egg/knightos/__main__.py", line 90, in <module>
    local_path=args["--local-path"])
  File "/usr/local/lib/python3.7/site-packages/knightos-2.0.3_13_ga0841f4-py3.7.egg/knightos/commands/install.py", line 12, in execute
    ws.require_package(package, local_path=local_path)
  File "/usr/local/lib/python3.7/site-packages/knightos-2.0.3_13_ga0841f4-py3.7.egg/knightos/workspace.py", line 110, in require_package
    self.install_package(package, local_path)
  File "/usr/local/lib/python3.7/site-packages/knightos-2.0.3_13_ga0841f4-py3.7.egg/knightos/workspace.py", line 142, in install_package
    source, manifest = ensure_package(package.full_name)
  File "/usr/local/lib/python3.7/site-packages/knightos-2.0.3_13_ga0841f4-py3.7.egg/knightos/package.py", line 29, in full_name
    return "{}/{}".format(self.repo, self.name)
AttributeError: 'WorkspacePackage' object has no attribute 'repo'
```